### PR TITLE
Add DSL-JSON to bench.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -135,6 +135,19 @@
         <version>1.0.0</version>
       </dependency>
 
+        <dependency>
+            <groupId>com.dslplatform</groupId>
+            <artifactId>dsl-json</artifactId>
+            <version>0.9.5</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.dslplatform</groupId>
+            <artifactId>dsl-json-processor</artifactId>
+            <version>0.4</version>
+            <scope>provided</scope>
+        </dependency>
+
     </dependencies>
 
     <build>
@@ -146,6 +159,10 @@
             <configuration>
               <source>1.7</source>
               <target>1.7</target>
+                <annotationProcessors>
+                    <annotationProcessor>com.dslplatform.json.CompiledJsonProcessor</annotationProcessor>
+                    <annotationProcessor>org.openjdk.jmh.generators.BenchmarkProcessor</annotationProcessor>
+                </annotationProcessors>
               <showDeprecation>true</showDeprecation>
               <showWarnings>true</showWarnings>
               <optimize>true</optimize>

--- a/src/main/java/com/cowtowncoder/jsonperf/dzone/MeasurementPOJO.java
+++ b/src/main/java/com/cowtowncoder/jsonperf/dzone/MeasurementPOJO.java
@@ -1,11 +1,14 @@
 package com.cowtowncoder.jsonperf.dzone;
 
+import com.dslplatform.json.CompiledJson;
+
 import java.util.List;
 
 /**
  * Simple wrapper used to contain List of items to (de)serialize; used to avoid
  * need to  handle generic types like Lists for root values;
  */
+@CompiledJson
 public class MeasurementPOJO
 {
     public List<MeasurementRecord> items;

--- a/src/main/java/com/cowtowncoder/jsonperf/dzone/MeasurementRecord.java
+++ b/src/main/java/com/cowtowncoder/jsonperf/dzone/MeasurementRecord.java
@@ -20,7 +20,7 @@ public class MeasurementRecord
     public long time;
 
     // for deser
-    protected MeasurementRecord() { }
+    public MeasurementRecord() { }
     
     public MeasurementRecord(String measurementId, MeasurementType type,
             long duration, long time)

--- a/src/main/java/com/cowtowncoder/jsonperf/dzone/read/DZoneReadPojoDslJson.java
+++ b/src/main/java/com/cowtowncoder/jsonperf/dzone/read/DZoneReadPojoDslJson.java
@@ -1,0 +1,31 @@
+package com.cowtowncoder.jsonperf.dzone.read;
+
+import com.cowtowncoder.jsonperf.dzone.MeasurementPOJO;
+import com.dslplatform.json.DslJson;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.State;
+
+import java.util.concurrent.TimeUnit;
+
+@State(Scope.Thread)
+@OutputTimeUnit(TimeUnit.SECONDS)
+public class DZoneReadPojoDslJson extends DZoneReadTestBase<MeasurementPOJO>
+{
+    private final DslJson<Object> dsl;
+
+    public DZoneReadPojoDslJson()
+    {
+        dsl = new DslJson<>();
+    }
+
+    @Override
+    public MeasurementPOJO _readItems(byte[] input) throws Exception {
+        return dsl.deserialize(MeasurementPOJO.class, input, input.length);
+    }
+
+    @Override
+    public MeasurementPOJO _readItems(String input) throws Exception {
+        return _readItems(input.getBytes("UTF-8"));
+    }
+}

--- a/src/main/java/com/cowtowncoder/jsonperf/dzone/write/DZoneWriteDslJson.java
+++ b/src/main/java/com/cowtowncoder/jsonperf/dzone/write/DZoneWriteDslJson.java
@@ -1,0 +1,51 @@
+package com.cowtowncoder.jsonperf.dzone.write;
+
+import com.cowtowncoder.jsonperf.dzone.MeasurementPOJO;
+import com.dslplatform.json.DslJson;
+import com.dslplatform.json.JsonWriter;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.State;
+
+import java.io.OutputStream;
+import java.io.Writer;
+import java.util.concurrent.TimeUnit;
+
+@State(Scope.Thread)
+@OutputTimeUnit(TimeUnit.SECONDS)
+public class DZoneWriteDslJson extends DZoneWriteTestBase
+{
+    private final DslJson<Object> json;
+    private final JsonWriter writer;
+
+    public DZoneWriteDslJson()
+    {
+        json =  new DslJson<>();
+        writer = new JsonWriter();
+    }
+
+    @Override
+    public int _writeItems(MeasurementPOJO items, OutputStream out) throws Exception
+    {
+        writer.reset();
+        json.serialize(writer, items);
+        writer.toStream(out);
+        return items.size();
+    }
+
+    @Override
+    public int _writeItems(MeasurementPOJO items, Writer out) throws Exception
+    {
+        writer.reset();
+        json.serialize(writer, items);
+        out.write(writer.toString());
+        return items.size();
+    }
+
+    @Override
+    public String _writeAsString(MeasurementPOJO items) throws Exception {
+        writer.reset();
+        json.serialize(writer, items);
+        return writer.toString();
+    }
+}


### PR DESCRIPTION
Requires Mono/.NET for compilation.

Added @CompiledJson to MeasurementPOJO (alternative is to create another POJO referencing MeasurementPOJO)
Changed empty ctor on MeasurementRecord to public.

Results:

| Benchmark | Mode | Cnt | Score | Error | Units |
| --- | --- | --- | --- | --- | --- |
| DZoneReadPojoBoon.read10FromString | thrpt | 6 | 78491.365 | ± 29262.098 | ops/s |
| DZoneReadPojoDslJson.read10FromString | thrpt | 6 | 255100.183 | ± 13913.517 | ops/s |
| DZoneReadPojoGSON.read10FromString | thrpt | 6 | 121667.213 | ± 26262.467 | ops/s |
| DZoneReadPojoJackson.read10FromString | thrpt | 6 | 145797.860 | ± 40340.347 | ops/s |
| DZoneReadPojoJacksonAB.read10FromString | thrpt | 6 | 176709.197 | ± 28909.546 | ops/s |
| DZoneReadPojoJacksonJr.read10FromString | thrpt | 6 | 155634.482 | ± 33556.527 | ops/s |
| DZoneReadPojoJohnzon.read10FromString | thrpt | 6 | 63283.833 | ± 11793.431 | ops/s |
| DZoneReadPojoMoshi.read10FromString | thrpt | 6 | 66843.351 | ± 15100.781 | ops/s |

| Benchmark | Mode | Cnt | Score | Error | Units |
| --- | --- | --- | --- | --- | --- |
| DZoneWriteBoon.write100kUsingStream | thrpt | 6 | 12.556 | ±  2.872 | ops/s |
| DZoneWriteDslJson.write100kUsingStream | thrpt | 6 | 73.004 | ± 17.470 | ops/s |
| DZoneWriteGSON.write100kUsingStream | thrpt | 6 | 4.796 | ±  1.612 | ops/s |
| DZoneWriteJackson.write100kUsingStream | thrpt | 6 | 41.553 | ±  2.356 | ops/s |
| DZoneWriteJacksonAB.write100kUsingStream | thrpt | 6 | 43.839 | ± 10.611 | ops/s |
| DZoneWriteJacksonJr.write100kUsingStream | thrpt | 6 | 32.052 | ±  7.498 | ops/s |
| DZoneWriteJohnzon.write100kUsingStream | thrpt | 6 | 15.352 | ±  1.939 | ops/s |
| DZoneWriteJsonIO.write100kUsingStream | thrpt | 6 | 7.397 | ±  0.817 | ops/s |
| DZoneWriteMoshi.write100kUsingStream | thrpt | 6 | 10.868 | ±  2.244 | ops/s |
